### PR TITLE
GIF path "fix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Animating with React, Redux, and d3
 
-![Gif](react-particles-experiment/particles-step-5.gif)
+![Gif](https://raw.githubusercontent.com/Swizec/react-particles-experiment/master/particles-step-5.gif)
 
 That's a particle generator. It makes tiny circles fly out of where you click. Hold down your mouse and move around. The particles keep flying out of your cursor.
 


### PR DESCRIPTION
Relative path to IMG files don't work on Github, so you'll need to have an ugly static one,
sadly this will break when branching, cloning and forking the repo it will still show your master one.
Another option is to host it somewhere...
Your choice :)
